### PR TITLE
Adjust for new way Test::More preserves vars

### DIFF
--- a/t/20_DPeek.t
+++ b/t/20_DPeek.t
@@ -26,7 +26,13 @@ like (DPeek ($:), qr'^PVMG\(" \\(n|12)-"\\0\)',	'$:');
   is (DPeek ($=),    'PVMG()',			'$=');
   is (DPeek ($-),    'PVMG()',			'$-');
   is (DPeek ($|),    'PVMG(1)',			'$|');
-like (DPeek ($?), qr'^PV(MG|LV)\(\)',		'$?');
+
+{
+    local $?; # Test::More protects the value, but not the magic flags.
+    like (DPeek ($?), qr'^PV(MG|LV)\(\)',		'$?');
+}
+
+  my $x = "$!";
 like (DPeek ($!), qr'^PVMG\("',			'$!');
 
   "abc" =~ m/(b)/;	# Don't know why these magic vars have this content


### PR DESCRIPTION
Test::More no longer uses 'local' to protect $!, $? and $@. Instead it
stores the values and restores them in another way. This was discussed
on cpan-workers, and it was noticed that it means that magic flags are
not always preserved. It was decided that this was acceptible.

There is also a patch for p5p that has an almost identical fix to a
nearly identical XS test.
